### PR TITLE
ItemSpacing on CollectionView fix

### DIFF
--- a/Sharpnado.CollectionView.Droid/Renderers/MeasureHelper.cs
+++ b/Sharpnado.CollectionView.Droid/Renderers/MeasureHelper.cs
@@ -4,7 +4,7 @@ namespace Sharpnado.CollectionView.Droid.Renderers
 {
     public static class MeasureHelper
     {
-        public const int RecyclerViewItemVerticalMarginDp = 2;
+        public const int RecyclerViewItemVerticalMarginDp = 0;
 
         public static int ComputeSpan(int availableWidth, CollectionView.RenderedViews.CollectionView element)
         {


### PR DESCRIPTION
I don't know the reason for this constant that adds a margin between each item. Why not leave it at 0?
As it is right now, if we set ItemSpacing to 0 there is still a space generated by this constant, we need to set ItemSpacing = -2 (and change the code a bit to allow negative numbers) so that there is no spacing between items.

``RecyclerViewItemVerticalMarginDp = 2`` ``ItemSpacing = 0``
![image](https://user-images.githubusercontent.com/47887015/194851779-b9d42c0f-2fb3-445c-b614-61c519248173.png)

``RecyclerViewItemVerticalMarginDp = 0`` ``ItemSpacing = 0``
![image](https://user-images.githubusercontent.com/47887015/194851914-65a39118-98bd-4b3d-8c46-3732270d01a9.png)
