### PR TITLE
Force to update CurrentIndex before scroll ended (during scroll)

### DIFF
--- a/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.OnControlScrollChangedListener.cs
+++ b/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.OnControlScrollChangedListener.cs
@@ -40,6 +40,13 @@ namespace Sharpnado.CollectionView.Droid.Renderers
 
                 _currentOffset += dx;
 
+                if (_element.ForceToUpdateCurrentIndexDuringScroll && _weakNativeView.TryGetTarget(out CollectionViewRenderer nativeView))
+                {
+                    _cts?.Cancel();
+                    _cts = new CancellationTokenSource();
+                    UpdateCurrentIndex(nativeView, _cts.Token);
+                }
+
                 var infiniteListLoader = _element?.InfiniteListLoader;
                 if (infiniteListLoader == null)
                 {

--- a/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
+++ b/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
@@ -217,6 +217,12 @@ namespace Sharpnado.CollectionView.RenderedViews
             typeof(CollectionView),
             1);
 
+        public static readonly BindableProperty ForceToUpdateCurrentIndexDuringScrollProperty = BindableProperty.Create(
+            nameof(ForceToUpdateCurrentIndexDuringScroll),
+            typeof(bool),
+            typeof(CollectionView),
+            false);
+
         public CollectionView()
         {
             // default layout is VerticalList
@@ -363,6 +369,12 @@ namespace Sharpnado.CollectionView.RenderedViews
         {
             get => (int)GetValue(ColumnCountProperty);
             set => SetValue(ColumnCountProperty, value);
+        }
+
+        public bool ForceToUpdateCurrentIndexDuringScroll
+        {
+            get => (bool)GetValue(ForceToUpdateCurrentIndexDuringScrollProperty);
+            set => SetValue(ForceToUpdateCurrentIndexDuringScrollProperty, value);
         }
 
         public Func<ViewCell, Task> PreRevealAnimationAsync { get; set; }


### PR DESCRIPTION
CurrentIndex is only updated when scroll finishes. It is probably done this way for performance, but for our specific case we need it to be constantly updated. We have added the possibility through a boolean property which is false by default.