### PR TITLE
Fixed UI Thread desynchrony when modifying ItemSource

### DIFF
--- a/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.RecycleViewAdapter.cs
+++ b/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.RecycleViewAdapter.cs
@@ -19,7 +19,7 @@ using Sharpnado.CollectionView.Droid.Helpers;
 using Sharpnado.CollectionView.Helpers;
 using Sharpnado.CollectionView.RenderedViews;
 using Sharpnado.Tasks;
-
+using Xamarin.Essentials;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android;
 
@@ -422,8 +422,8 @@ namespace Sharpnado.CollectionView.Droid.Renderers
                 _formsViews.Add(new WeakReference<ViewCell>(viewCell));
                 var view = viewCell.View;
 
-                var renderer = Platform.CreateRendererWithContext(view, _context);
-                Platform.SetRenderer(view, renderer);
+                var renderer = Xamarin.Forms.Platform.Android.Platform.CreateRendererWithContext(view, _context);
+                Xamarin.Forms.Platform.Android.Platform.SetRenderer(view, renderer);
 
                 renderer.Element.Layout(new Rectangle(0, 0, itemWidth, itemHeight));
                 renderer.UpdateLayout();
@@ -512,8 +512,7 @@ namespace Sharpnado.CollectionView.Droid.Renderers
             private void OnItemReplaced(int itemIndex, object newItem)
             {
                 InternalLogger.Info($"OnItemReplaced( itemIndex: {itemIndex} )");
-                using var h = new Handler(Looper.MainLooper);
-                h.Post(
+                MainThread.BeginInvokeOnMainThread(
                     () =>
                     {
                         if (_isDisposed)
@@ -530,8 +529,7 @@ namespace Sharpnado.CollectionView.Droid.Renderers
             private void OnItemMoved(int from, int to)
             {
                 InternalLogger.Info($"OnItemMoved( from: {from}, to: {to} )");
-                using var h = new Handler(Looper.MainLooper);
-                h.Post(
+                MainThread.BeginInvokeOnMainThread(
                     () =>
                     {
                         if (_isDisposed)
@@ -550,8 +548,7 @@ namespace Sharpnado.CollectionView.Droid.Renderers
             private void OnItemAdded(int newIndex, IList items)
             {
                 InternalLogger.Info($"OnItemAdded( newIndex: {newIndex}, itemCount: {items.Count} )");
-                using var h = new Handler(Looper.MainLooper);
-                h.Post(
+                MainThread.BeginInvokeOnMainThread(
                     () =>
                     {
                         if (_isDisposed)
@@ -574,8 +571,7 @@ namespace Sharpnado.CollectionView.Droid.Renderers
             private void OnItemRemoved(int removedIndex, int itemCount)
             {
                 InternalLogger.Info($"OnItemRemoved( newIndex: {removedIndex}, itemCount: {itemCount} )");
-                using var h = new Handler(Looper.MainLooper);
-                h.Post(
+                MainThread.BeginInvokeOnMainThread(
                     () =>
                     {
                         if (_isDisposed)

--- a/Sharpnado.CollectionView.Droid/Sharpnado.CollectionView.Droid.csproj
+++ b/Sharpnado.CollectionView.Droid/Sharpnado.CollectionView.Droid.csproj
@@ -70,6 +70,9 @@
     <Compile Include="Renderers\ViewHolderQueue.cs" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.7.3</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2196</Version>
     </PackageReference>


### PR DESCRIPTION
```
using var h = new Handler(Looper.MainLooper);
h.Post(
    () =>
    {
        // Code executed on UI Thread
    });
```
By using this code, you are passing an action to the main thread, enqueued, and it will be executed when the main thread finishes all the tasks ahead of it.

If I'm not wrong, this is exactly the same as using Device.BeginInvokeOnMainThread from Xamarin.Forms.

I have replaced the code with the Xamarin.Essentials implementation of MainThread.BeginInvokeOnMainThread.
_(**Note**: Device.BeginInvokeOnMainThread and MainThread.BeginInvokeOnMainThread do not work exactly the same: https://github.com/xamarin/Essentials/issues/1070)_

Device.BeginInvokeOnMainThread always enqueues the Action (like the code does right now). MainThread.BeginInvokeOnMainThread first checks if the current thread is the interface thread, in which case the Action is executed directly. If the current thread is not the interface thread, then it has the same behavior as Device.BeginInvokeOnMainThread.

In our specific case, since it was not executed directly if it was in the interface thread, it caused us a synchrony error. We were modifying the list by adding a new item (being in the interface thread) and then we wanted to scroll to this new item. Since the method that adds the new item to the internal list is in the execution queue, the scroll was executing before the item itself was added internally.
