### PR TITLE
Carousel didn't work well when inside horizontall scroll

### DIFF
--- a/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.cs
+++ b/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.cs
@@ -53,6 +53,12 @@ namespace Sharpnado.CollectionView.Droid.Renderers
         {
         }
 
+        public override bool OnInterceptTouchEvent(MotionEvent ev)
+        {
+            RequestDisallowInterceptTouchEvent(Element.HaveToDisallowInterceptTouchEvent);
+            return base.OnInterceptTouchEvent(ev);
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<CollectionView.RenderedViews.CollectionView> e)
         {
             base.OnElementChanged(e);

--- a/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
+++ b/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
@@ -217,6 +217,12 @@ namespace Sharpnado.CollectionView.RenderedViews
             typeof(CollectionView),
             1);
 
+        public static readonly BindableProperty HaveToDisallowInterceptTouchEventProperty = BindableProperty.Create(
+            nameof(HaveToDisallowInterceptTouchEvent),
+            typeof(bool),
+            typeof(CollectionView),
+            false);
+
         public CollectionView()
         {
             // default layout is VerticalList
@@ -363,6 +369,12 @@ namespace Sharpnado.CollectionView.RenderedViews
         {
             get => (int)GetValue(ColumnCountProperty);
             set => SetValue(ColumnCountProperty, value);
+        }
+
+        public bool HaveToDisallowInterceptTouchEvent
+        {
+            get => (bool)GetValue(HaveToDisallowInterceptTouchEventProperty);
+            set => SetValue(HaveToDisallowInterceptTouchEventProperty, value);
         }
 
         public Func<ViewCell, Task> PreRevealAnimationAsync { get; set; }


### PR DESCRIPTION
This is a bug that also occurs with the CarouselView from Xamarin.Forms. It is a problem that exists with Android when deciding the scroll priority for a component (https://github.com/xamarin/Xamarin.Forms/issues/9315).

My proposed solution is to force touchscreen detection on the component based on a property.
When the scroll direction of the Carousel (or any scrollable component) matches the scroll direction of the parent component (a list in my case) is when the problem occurs. If the Carousel is inside a vertical list, it works fine (and there is no point in forcing touch screen detection).
I've used a property for this because I don't know how to determine when it's needed by code.

Without changes:

https://user-images.githubusercontent.com/47887015/195582169-c42d8f1b-37d2-44d0-a667-7150700f483c.mp4

With changes:

https://user-images.githubusercontent.com/47887015/195581844-733f1b12-0d3a-422d-9cf1-65f281479d12.mp4
