### PR TITLE
Carousel offset is not calculated correctly when height is greater than width

### DIFF
--- a/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.cs
+++ b/Sharpnado.CollectionView.Droid/Renderers/CollectionViewRenderer.cs
@@ -133,12 +133,13 @@ namespace Sharpnado.CollectionView.Droid.Renderers
             int width = right - left;
             int height = bottom - top;
 
+            base.OnLayout(changed, left, top, right, bottom);
+
             if (ComputeItemSize(width, height))
             {
                 UpdateItemsSource();
             }
 
-            base.OnLayout(changed, left, top, right, bottom);
             _forceLayout = false;
         }
 


### PR DESCRIPTION
I think this is related to this issue #76 

From what I've seen debugging, in the ``ScrollToCurrentItem()`` method of Android Renderer, Control.MeasuredWidth will always be 0 when the height is greater than width (and offset will always be negative).
```
private void ScrollToCurrentItem()
{
    ...
    int offset = 0;
    if (HorizontalLinearLayoutManager != null)
    {
        int itemWidth = PlatformHelper.Instance.DpToPixels(
            Element.ItemWidth
            + Element.ItemSpacing
            + Element.CollectionPadding.HorizontalThickness);

        int width = Control.MeasuredWidth;

        switch (Element.SnapStyle)
        {
            case SnapStyle.Center:
                offset = (width / 2) - (itemWidth / 2);
                break;
        }
    }

    LinearLayoutManager?.ScrollToPositionWithOffset(Element.CurrentIndex, offset);
    GridLayoutManager?.ScrollToPositionWithOffset(Element.CurrentIndex, offset);
}
```

But when the width is greater than height, ``OnPreDraw()`` will call ``ScrollToCurrentItem()`` one more time, this time with values in the width and height that are used.
```
private void OnPreDraw(object sender, ViewTreeObserver.PreDrawEventArgs e)
{
    ...
    if (Control.Height < Control.Width)
    {
        if (!_isLandscape)
        {
            orientationChanged = true;
            _isLandscape = true;

            // Has just rotated
            if (HorizontalLinearLayoutManager != null)
            {
                ScrollToCurrentItem();
            }
        }
    }
    ...
}
```
So the problem here is that ``ScrollToCurrentItem()`` never is called with height and width values when the height is greater than width.

With the changes, inside the ``OnLayout()`` override, ``base.OnLayout()`` is called  before ``ComputeItemSize()`` so the Control will have height and width values when ``ScrollToCurrentItem()`` is evaluated.

Before changes:
![image](https://user-images.githubusercontent.com/47887015/195589380-a7506308-7a3d-4356-bfef-9674bb778506.png)

After changes:
![image](https://user-images.githubusercontent.com/47887015/195589419-a07d28a5-fba5-4fa3-a867-fbb642098759.png)

