### PR TITLE
Fixed memory leak in iOS/MAUI

### DIFF
--- a/Maui/Sharpnado.CollectionView.Maui/Platforms/iOS/Renderers/CollectionViewRenderer.cs
+++ b/Maui/Sharpnado.CollectionView.Maui/Platforms/iOS/Renderers/CollectionViewRenderer.cs
@@ -85,6 +85,15 @@ namespace Sharpnado.CollectionView.iOS.Renderers
             base.Dispose(disposing);
         }
 
+#if NET6_0_OR_GREATER
+        protected override void DisconnectHandler(UICollectionView oldNativeView)
+        {
+            CleanUp();
+
+            base.DisconnectHandler(oldNativeView);
+        }
+#endif
+
         protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             switch (e.PropertyName)

--- a/Xamarin.Forms/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
+++ b/Xamarin.Forms/Sharpnado.CollectionView/RenderedViews/CollectionView.cs
@@ -242,12 +242,30 @@ public class CollectionView : View
         typeof(CollectionView),
         1);
 
+#if NET6_0_OR_GREATER
+    public static readonly BindableProperty AutoDisconnectHandlerProperty = BindableProperty.Create(
+        nameof(AutoDisconnectHandler),
+        typeof(bool),
+        typeof(CollectionBase),
+        true);
+#endif
+
     public CollectionView()
     {
         // default layout is VerticalList
         SnapStyle = SnapStyle.None;
         ColumnCount = 1;
         ScrollSpeed = ScrollSpeed.Normal;
+
+#if NET6_0_OR_GREATER
+        Unloaded += (_, _) =>
+        {
+            if (AutoDisconnectHandler)
+            {
+                Handler?.DisconnectHandler();
+            }
+        };
+#endif
     }
 
     public event EventHandler<CollectionLayoutChangedEventArgs> CollectionLayoutChanging;
@@ -419,6 +437,18 @@ public class CollectionView : View
         get => (int)GetValue(ColumnCountProperty);
         set => SetValue(ColumnCountProperty, value);
     }
+
+#if NET6_0_OR_GREATER
+    /// <summary>
+    /// Default is true. If set to false, you will have to call <see cref="Handler.DisconnectHandler"/>
+    /// manually to prevent memory leaks.
+    /// </summary>
+    public bool AutoDisconnectHandler
+    {
+        get => (bool)GetValue(AutoDisconnectHandlerProperty);
+        set => SetValue(AutoDisconnectHandlerProperty, value);
+    }
+#endif
 
     public Func<ViewCell, Task> PreRevealAnimationAsync { get; set; }
 


### PR DESCRIPTION
Fixed #56 in MAUI. I don't know if the leak exists in Xamarin.Forms or not.

On iOS in MAUI, it's necessary to call `DisconnectHandler()` to prevent the CollectionView from leaking. This is a big issue since the leak will cascade through the system.Parent property to the containing page and prevent it from being garbage collected.

This PR introduces a new BindableProperty on the CollectionView `AutoDisconnectHandler`, which is true by default and will call `DisconnectHandler()` during the `Unload` event.

I added the bindable property because, while automatically disconnecting the handler on unload is what most developers will want 99% of the time, you may not want this if the CollectionView is intentionally being _temporarily_ removed from the main object tree. In these cases, the bindable property allows developers to opt out of this automatic behavior and assume responsibility for calling `DisconnectHandler()` themselves.