### PR TITLE
Another iOS memory leak

### DIFF
--- a/Maui/Sharpnado.CollectionView.Maui/Platforms/iOS/Renderers/CollectionViewRenderer.cs
+++ b/Maui/Sharpnado.CollectionView.Maui/Platforms/iOS/Renderers/CollectionViewRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Specialized;
 using System.ComponentModel;
@@ -144,10 +144,10 @@ namespace Sharpnado.CollectionView.iOS.Renderers
         {
             if (_collectionView != null)
             {
-                _collectionView.Dispose();
                 _collectionView.DataSource?.Dispose();
                 _collectionView.CollectionViewLayout?.Dispose();
                 _collectionView.Delegate?.Dispose();
+                _collectionView.Dispose();
                 _collectionView = null;
             }
 


### PR DESCRIPTION
PR #112 fixed an iOS memory leak that would manifest itself if even an empty `CollectionView` was added to a view. Unfortunately, this wasn't the only leak on the iOS side.

This PR also addresses #56 . Once items are added to a `CollectionView`, a separate leak occurs. This leak can be avoided by rearranging the order in which platform objects are disposed in `CleanUp()`. 

@roubachof I think there might be one or two more leaks on the iOS side. If so, expect another PR or two in the next few days.